### PR TITLE
Remove usage of alias_method_chain

### DIFF
--- a/lib/maybe_so/active_model.rb
+++ b/lib/maybe_so/active_model.rb
@@ -9,7 +9,8 @@ module ActiveModel
           include MaybeSo::ActiveModel::BooleanAttribute
         end
       end
-      alias_method_chain :included, :boolean_attribute
+      alias_method :included_without_boolean_attribute, :included
+      alias_method :included, :included_with_boolean_attribute
     end
   end
 end


### PR DESCRIPTION
This is deprecated in Rails 5 and removed in Rails 5.1.